### PR TITLE
Add line break to fix "broken headers" in rspamd to avoid confirmation mails gettings stuck in spam filter

### DIFF
--- a/lib/send.php
+++ b/lib/send.php
@@ -57,7 +57,7 @@ class password_recovery_send {
         $headers .= "Subject: $subject\r\n";
         $headers .= "Reply-To: $from\r\n";
 
-        $txt_body  = "--=_$ctb";
+        $txt_body  = "--=_$ctb\r\n";
         $txt_body .= "\r\n";
         $txt_body .= "Content-Transfer-Encoding: 7bit\r\n";
         $txt_body .= "Content-Type: text/plain; charset=" . $this->rc->config->get('default_charset', RCUBE_CHARSET) . "\r\n";

--- a/localization/de_DE.inc
+++ b/localization/de_DE.inc
@@ -1,0 +1,58 @@
+<?php
+
+$labels['forgot_password']          = 'Passwort vergessen?';
+$labels['recovery_password']        = 'Wiederhestellungspasswort';
+$labels['phone']                    = 'Telefon';
+$labels['altemail']                 = 'Alternative E-Mail Adresse';
+$labels['newpassword']              = 'Neues Passwort';
+$labels['newpassword_confirm']      = 'Bestätigung';
+$labels['code']                     = 'Bestätigungs-Code';
+$labels['question']                 = 'Geheime Frage';
+$labels['answer']                   = 'Antwort auf geheime Frage';
+$labels['answer_confirm']           = 'Bestätigung';
+$labels['recovery']                 = 'Wiederherstellung';
+$labels['save']                     = 'Speichern';
+$labels['cancel']                   = 'Abbrechen';
+$labels['email_subject']            = 'E-Mail Zugang wiederherstellen';
+$labels['email_subject_admin']      = 'Anfrage zur Passwort Wiederherstellung';
+$labels['click_here']               = 'Hier klicken';
+$labels['no_identities']            = 'Information zur Passwort-Wiederherstellung ausfüllen.';
+$labels['no_username']              = 'Benutzernamen eingeben (E-mail Addresse)';
+$labels['renew_code']               = 'Neuen Wiederherstellungs-Code senden';
+$labels['count_send_code_maximum']  = 'Maximale Anzahl erlaubter Wiederherstellungs-Codes überschritten';
+$labels['no_code']                  = 'Bestätigungscode eingeben';
+$labels['no_answer']                = 'Geheime Antwort eingeben';
+$labels['no_password']              = 'Neues Passwort eingeben';
+$labels['no_password_confirm']      = 'Passwort-Bestätigung eingeben';
+$labels['password_inconsistency']   = 'Passwort und Bestätigung stimmen nicht überein';
+$labels['password_too_short']       = 'Das Passwort muss mundestens %d Zeichen lang sein.';
+
+$messages['disabled']               = 'Das System ist im Wartungsmodus und eine Passwort-Wiederherstellungs ist momentan nicht möglich. Das System sollte in Kürze wieder normal laufen. Entschuldigung für Unannehmlichkeiten.';
+$messages['banned']                 = 'Zugang vorübergehend gesperrt (zu viele Login Versuche). Bitte versuchen Sie es später noch einmal oder kontaktieren Sie den Administrator.';
+$messages['no_identities']          = 'The Einstellungen für die Passwort-Wiederherstellung sind nicht vorhanden. %s und konfiguriere!';
+$messages['user_not_found']         = 'Benutzer nicht gefunden';
+$messages['check_account_notice']   = 'Der Passwort-Wiederherstellungscode wurde bereits versandt. Bitte überprüfen Sie ihre Email oder das Telefon';
+$messages['check_account']          = 'Passwort-Wiederherstellungscode wurde an Sie versandt ';
+$messages['check_email']            = 'an eine alternative E-Mail Adresse ';
+$messages['check_sms']              = 'am Telefon';
+$messages['and']                    = 'und ';
+$messages['sent_to_admin']          = 'Passwort-Wiederherstellungsinformationen konnten nicht gefunden werden, daher wurde eine Nachricht an den Administrator gesandt.';
+$messages['send_failed']            = 'Fehler beim Versenden des Wiederherstellungs-Codes. Bitte später noch ein mal versuchen.';
+$messages['write_failed']           = 'Fehler beim Schreiben der Daten. bitte den Administrator kontaktieren.';
+$messages['code_expired']           = 'Wiederherstellungs-Code ist abgelaufen';
+$messages['code_failed']            = 'Ungültiger Wiederherstellungs-Code';
+$messages['answer_failed']          = 'Falsche Antwort auf die geheime Frage';
+$messages['password_invalid']       = 'Ungültiges asswort';
+$messages['password_check_failed']  = 'Fehler. Das Passwort is zu einfach!';
+$messages['password_forbidden']     = 'Das Passwort beinhaltet ungültige Zeichen';
+$messages['password_changed']       = 'Passwortänderung erfolgreich!';
+$messages['password_not_changed']   = 'Beim Ändern des Passwortes kam es zu einem Fehler. Bitte später noch ein mal versuchen, oder den Administrator verständigen.';
+$messages['crypt_error']            = 'Ich kann das neue Passwort nicht speichern. Fehlende kryptographische Funktion.';
+$messages['connect_error']          = 'Ich kann das neue Passwort nicht speichern. Verbindungsproblem.';
+$messages['password_in_history']    = 'Dieses Passwort wurde bereits verwendet.';
+$messages['password_const_viol']    = 'Verstoß gegen die Passwort-Richtlinien. Das Passwort könnte zu schwach sein.';
+$messages['phone_invalid']          = 'Falsche Telefonnummer! Nummer muss %d Zeichen sein';
+$messages['altemail_invalid']       = 'Die alternative E-Mail Adresse ist ungültig!';
+$messages['altemail_match_primary'] = 'Die alternative E-Mail Adresse muss sich von der primären Adresse unterscheiden. Die zwei Adressen dürfen nicht ident sein!';
+
+?>

--- a/localization/de_DE/alert_for_admin_to_reset_pw.html
+++ b/localization/de_DE/alert_for_admin_to_reset_pw.html
@@ -1,0 +1,2 @@
+<p>BenutzerIn [USER] hat eine Passwort-Wiederherstellung angefragt, aber weder eine Telefonnummer noch eine alternative E-Mail Adresse konfiguriert.</p>
+<p>Bitte ändere das Passwort manuell, oder konfiguriere eine Telefonnummer und/oder eine alternative A-Mail Adresse für den oder die betroffene Benutzerin.</p>

--- a/localization/de_DE/reset_pw_body.html
+++ b/localization/de_DE/reset_pw_body.html
@@ -1,0 +1,3 @@
+<p>Hallo!</p>
+<p>Sie haben einen Code für eine Passwort-Wiederherstellung angefragt.</p>
+<p>Bestätigungs-Code: [CODE]</p>


### PR DESCRIPTION
Sending emails with the confirmation code got stuck in rspamd spam filter. Rspamd complained about "broken headers", and added +10 scores for this issue, marking it as spam.
After running
rspamadm mime modify confirmation-code.eml > rspamd-modified-mail.eml
and comparing the files I noticed that rspamd expects an additional line break after the boundary.

Adding this one additional line break makes rspamd accept the confirmation email, and the confirmation emails will be delivered.


(I am sorry, I noticed that the added localization is already in master, but I don't manage to create the pull request with the added line break only).